### PR TITLE
6.8 kernel k3s v1.32.0

### DIFF
--- a/CUTTING_A_RELEASE.md
+++ b/CUTTING_A_RELEASE.md
@@ -6,7 +6,7 @@
 ENV VERSION vx.x.x+xxx
 ```
 * run `make`
-* tag docker image with version label: `docker tag k3os:latest jeffherald/k3os:<release tag>`
+* tag docker image with version label: `docker tag rancher/k3os:latest jeffherald/k3os:<release tag>`
 * push to dockerhub: `docker push jeffherald/k3os:<release tag>`
 * tag release in git: `git tag <releae tag>` ex. v0.28.5-k3s1r0
 * push tag: `git push origin <release tag>`

--- a/Dockerfile.dapper2966462894
+++ b/Dockerfile.dapper2966462894
@@ -1,0 +1,19 @@
+FROM golang:1.16-alpine3.14
+
+ARG DAPPER_HOST_ARCH
+ENV ARCH $DAPPER_HOST_ARCH
+
+RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
+RUN if [ "$(go env GOARCH)" = "arm64" ]; then \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.38.0; \
+    fi
+
+ENV DAPPER_RUN_ARGS --privileged -v /tmp:/tmp -v k3os-pkg:/go/pkg -v k3os-cache:/root/.cache/go-build
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /go/src/github.com/rancher/k3os/
+ENV DAPPER_OUTPUT ./build ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Dockerfile.dapper925404915
+++ b/Dockerfile.dapper925404915
@@ -1,0 +1,2 @@
+FROM k3os:6-8-kernel-k3s-v1-32-0
+COPY . /go/src/github.com/rancher/k3os/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # k3OS
 
+> [!WARNING] K3OS is no longer maintained or supported and should be used at your own risk.
+
 k3OS is a Linux distribution designed to remove as much OS maintenance
 as possible in a Kubernetes cluster. It is specifically designed to only
 have what is needed to run [k3s](https://github.com/rancher/k3s). Additionally

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -42,10 +42,12 @@ RUN apk --no-cache add \
     mdadm-misc \
     mdadm-udev \
     mdev-conf \
+    mg \
     multipath-tools \
     ncurses \
     ncurses-terminfo \
     nfs-utils \
+    nano \
     open-iscsi \
     openrc \
     openssh-client \
@@ -63,6 +65,7 @@ RUN apk --no-cache add \
     tar \
     tzdata \
     util-linux \
+    usbutils \
     vim \
     wireguard-tools \
     wpa_supplicant \

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -35,6 +35,7 @@ RUN apk --no-cache add \
     libc6-compat \
     libusb \
     logrotate \
+    lspci \
     lsscsi \
     lvm2 \
     lvm2-extra \
@@ -58,6 +59,7 @@ RUN apk --no-cache add \
     strace \
     smartmontools \
     sudo \
+    tailscale \
     tar \
     tzdata \
     util-linux \

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -1,11 +1,11 @@
 ### BASE ###
-FROM alpine:3.14 as base
+FROM alpine:3.21 as base
 ARG ARCH
 RUN apk --no-cache add \
     bash \
     bash-completion \
     blkid \
-    busybox-initscripts \
+    busybox-extras \
     ca-certificates \
     connman \
     conntrack-tools \
@@ -41,6 +41,7 @@ RUN apk --no-cache add \
     mdadm \
     mdadm-misc \
     mdadm-udev \
+    mdev-conf \
     multipath-tools \
     ncurses \
     ncurses-terminfo \

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -35,7 +35,6 @@ RUN apk --no-cache add \
     libc6-compat \
     libusb \
     logrotate \
-    lspci \
     lsscsi \
     lvm2 \
     lvm2-extra \
@@ -52,6 +51,7 @@ RUN apk --no-cache add \
     openssh-client \
     openssh-server \
     parted \
+    pciutils \
     procps \
     qemu-guest-agent \
     rng-tools \

--- a/images/10-gobuild/Dockerfile
+++ b/images/10-gobuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.14 AS gobuild
+FROM golang:1.23.5-alpine3.21 AS gobuild
 RUN apk -U add git gcc linux-headers musl-dev make libseccomp libseccomp-dev bash
 COPY gobuild /usr/bin/
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh

--- a/images/10-k3s/Dockerfile
+++ b/images/10-k3s/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REPO}/k3os-base:${TAG}
 
 ARG ARCH
 ENV ARCH ${ARCH}
-ENV VERSION v1.28.5+k3s1
+ENV VERSION v1.32.0+k3s1
 ADD https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh /output/install.sh
 ENV INSTALL_K3S_VERSION=${VERSION} \
     INSTALL_K3S_SKIP_START=true \

--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
         linux-headers-${KVERSION} \
         linux-image-${KVERSION} \
         linux-modules-${KVERSION} \
+        linux-modules-extra-${KVERSION} \
         lz4 \
         rsync \
         xz-utils \

--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -1,44 +1,51 @@
 ARG REPO
 ARG TAG
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
-RUN apt-get --assume-yes update \
- && apt-get --assume-yes install \
-    curl \
-    initramfs-tools \
-    kmod \
-    lz4 \
-    rsync \
-    xz-utils \
- && echo 'r8152' >> /etc/initramfs-tools/modules \
- && echo 'hfs' >> /etc/initramfs-tools/modules \
- && echo 'hfsplus' >> /etc/initramfs-tools/modules \
- && echo 'nls_utf8' >> /etc/initramfs-tools/modules \
- && echo 'nls_iso8859_1' >> /etc/initramfs-tools/modules
+ENV KVERSION=6.8.0-51-generic
+RUN sed -i -e 's/# deb-src/deb-src/g' /etc/apt/sources.list
+RUN apt update && \
+    apt install --assume-yes \
+        curl \
+        initramfs-tools \
+        kmod \
+        linux-firmware \
+        linux-headers-${KVERSION} \
+        linux-image-${KVERSION} \
+        linux-modules-${KVERSION} \
+        lz4 \
+        rsync \
+        xz-utils \
+    && echo 'r8152' >> /etc/initramfs-tools/modules \
+    && echo 'hfs' >> /etc/initramfs-tools/modules \
+    && echo 'hfsplus' >> /etc/initramfs-tools/modules \
+    && echo 'nls_utf8' >> /etc/initramfs-tools/modules \
+    && echo 'nls_iso8859_1' >> /etc/initramfs-tools/modules
 
 ARG ARCH
-ENV KVERSION=5.4.0-88-generic
-ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.4.0-88.99-rancher1
-ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
-ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz
-ENV KERNEL_HEADERS_XZ=${URL}/kernel-headers-generic_${ARCH}.tar.xz
 
-# Download kernel
-RUN mkdir -p /usr/src
-RUN curl -fL $KERNEL_XZ -o /usr/src/kernel.tar.xz
-RUN curl -fL $KERNEL_EXTRA_XZ -o /usr/src/kernel-extra.tar.xz
-RUN curl -fL $KERNEL_HEADERS_XZ -o /usr/src/kernel-headers.tar.xz
+# ENV KVERSION=5.4.0-88-generic
+# ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.4.0-88.99-rancher1
+# ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
+# ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz
+# ENV KERNEL_HEADERS_XZ=${URL}/kernel-headers-generic_${ARCH}.tar.xz
 
-# Extract to /usr/src/root
-RUN mkdir -p /usr/src/root && \
-    cd /usr/src/root && \
-    tar xvf /usr/src/kernel.tar.xz && \
-    tar xvf /usr/src/kernel-extra.tar.xz && \
-    tar xvf /usr/src/kernel-headers.tar.xz
+# # Download kernel
+# RUN mkdir -p /usr/src
+# RUN curl -fL $KERNEL_XZ -o /usr/src/kernel.tar.xz
+# RUN curl -fL $KERNEL_EXTRA_XZ -o /usr/src/kernel-extra.tar.xz
+# RUN curl -fL $KERNEL_HEADERS_XZ -o /usr/src/kernel-headers.tar.xz
+
+# # Extract to /usr/src/root
+# RUN mkdir -p /usr/src/root && \
+#     cd /usr/src/root && \
+#     tar xvf /usr/src/kernel.tar.xz && \
+#     tar xvf /usr/src/kernel-extra.tar.xz && \
+#     tar xvf /usr/src/kernel-headers.tar.xz
 
 # Create initrd
-RUN mkdir /usr/src/initrd && \
-    rsync -a /usr/src/root/lib/ /lib/ && \
+RUN mkdir -p /usr/src/initrd && \
+#    rsync -a /usr/src/root/lib/ /lib/ && \
     depmod $KVERSION && \
     mkinitramfs -k $KVERSION -c lz4 -o /usr/src/initrd.tmp
 
@@ -47,14 +54,14 @@ RUN mkdir -p /output/lib && \
     mkdir -p /output/headers && \
     cd /usr/src/initrd && \
     lz4cat /usr/src/initrd.tmp | cpio -idmv && \
-    find lib/modules -name \*.ko > /output/initrd-modules && \
+    find /lib/modules -name \*.ko | sed -e 's/^\/lib/lib/g' > /output/initrd-modules && \
     echo lib/modules/${KVERSION}/modules.order >> /output/initrd-modules && \
     echo lib/modules/${KVERSION}/modules.builtin >> /output/initrd-modules && \
-    find lib/firmware -type f > /output/initrd-firmware && \
+    cd /usr/src/initrd && find lib/firmware -type f > /output/initrd-firmware && \
     find usr/lib/firmware -type f | sed 's!usr/!!' >> /output/initrd-firmware
 
 # Copy output assets
-RUN cd /usr/src/root && \
+RUN cd / && \
     cp -r usr/src/linux-headers* /output/headers && \
     cp -r lib/firmware /output/lib/firmware && \
     cp -r lib/modules /output/lib/modules && \

--- a/images/40-kernel/Dockerfile
+++ b/images/40-kernel/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=kernel /output/ /usr/src/kernel/
 
 RUN mkdir -p /usr/src/initrd/lib && \
     cd /usr/src/kernel && \
-    tar cf - -T initrd-modules -T initrd-firmware | tar xf - -C /usr/src/initrd/ && \
+    tar cf - -T initrd-modules -T initrd-firmware | tar xvf - -C /usr/src/initrd/ && \
     depmod -b /usr/src/initrd $(cat /usr/src/kernel/version)
 
 RUN mkdir -p /output && \

--- a/install.sh
+++ b/install.sh
@@ -160,7 +160,7 @@ install_grub()
 set default=0
 set timeout=10
 
-set gfxmode=auto
+set gfxmode=1280x1024x16,auto
 set gfxpayload=keep
 insmod all_video
 insmod gfxterm

--- a/install.sh
+++ b/install.sh
@@ -81,11 +81,11 @@ do_format()
         BOOT_NUM=1
         STATE_NUM=2
         parted -s ${DEVICE} mkpart primary fat32 0% 50MB
-        parted -s ${DEVICE} mkpart primary ext4 50MB 1000MB
+        parted -s ${DEVICE} mkpart primary ext4 50MB 1500MB
     else
         BOOT_NUM=
         STATE_NUM=1
-        parted -s ${DEVICE} mkpart primary ext4 0% 1000MB
+        parted -s ${DEVICE} mkpart primary ext4 0% 1500MB
     fi
     parted -s ${DEVICE} set 1 ${BOOTFLAG} on
     partprobe ${DEVICE} 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -81,11 +81,11 @@ do_format()
         BOOT_NUM=1
         STATE_NUM=2
         parted -s ${DEVICE} mkpart primary fat32 0% 50MB
-        parted -s ${DEVICE} mkpart primary ext4 50MB 750MB
+        parted -s ${DEVICE} mkpart primary ext4 50MB 1000MB
     else
         BOOT_NUM=
         STATE_NUM=1
-        parted -s ${DEVICE} mkpart primary ext4 0% 700MB
+        parted -s ${DEVICE} mkpart primary ext4 0% 1000MB
     fi
     parted -s ${DEVICE} set 1 ${BOOTFLAG} on
     partprobe ${DEVICE} 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -81,11 +81,11 @@ do_format()
         BOOT_NUM=1
         STATE_NUM=2
         parted -s ${DEVICE} mkpart primary fat32 0% 50MB
-        parted -s ${DEVICE} mkpart primary ext4 50MB 1500MB
+        parted -s ${DEVICE} mkpart primary ext4 50MB 2048MB
     else
         BOOT_NUM=
         STATE_NUM=1
-        parted -s ${DEVICE} mkpart primary ext4 0% 1500MB
+        parted -s ${DEVICE} mkpart primary ext4 0% 2048MB
     fi
     parted -s ${DEVICE} set 1 ${BOOTFLAG} on
     partprobe ${DEVICE} 2>/dev/null || true

--- a/overlay/etc/conf.d/cgroups
+++ b/overlay/etc/conf.d/cgroups
@@ -1,0 +1,1 @@
+rc_cgroup_mode=unified

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -48,7 +48,7 @@ setup_services()
         ln -s /etc/init.d/$i /etc/runlevels/boot
     done
 
-    for i in sshd "local" ccapply iscsid; do
+    for i in sshd "local" ccapply iscsid tailscale; do
         ln -s /etc/init.d/$i /etc/runlevels/default
     done
 

--- a/pkg/cli/rc/rc.go
+++ b/pkg/cli/rc/rc.go
@@ -82,7 +82,7 @@ func symlink(oldpath string, newpath string) {
 // mkdirall with warning
 func mkdir(path string, perm os.FileMode) {
 	err := os.MkdirAll(path, perm)
-	if err != nil {
+	if err != nil && err != os.ErrExist {
 		log.Printf("error making directory %s: %v", path, err)
 	}
 }
@@ -245,8 +245,8 @@ func doMounts() {
 	//write("/sys/fs/cgroup/memory/memory.use_hierarchy", "1")
 
 	// many things assume systemd
-	mkdir("/sys/fs/cgroup/systemd", 0555)
-	mount("cgroup", "/sys/fs/cgroup/systemd", "cgroup2", 0, "none,name=systemd")
+	//mkdir("/sys/fs/cgroup/systemd", 0555)
+	//mount("cgroup", "/sys/fs/cgroup/systemd", "cgroup2", 0, "none,name=systemd")
 
 	// make / rshared
 	mount("", "/", "", rec|shared, "")

--- a/pkg/cli/rc/rc.go
+++ b/pkg/cli/rc/rc.go
@@ -237,7 +237,7 @@ func doMounts() {
 	for _, cg := range cgroupList() {
 		path := filepath.Join("/sys/fs/cgroup", cg)
 		mkdir(path, 0555)
-		mount(cg, path, "cgroup", noexec|nosuid|nodev, cg)
+		mount(cg, path, "cgroup2", noexec|nosuid|nodev, cg)
 	}
 
 	// use hierarchy for memory
@@ -245,7 +245,7 @@ func doMounts() {
 
 	// many things assume systemd
 	mkdir("/sys/fs/cgroup/systemd", 0555)
-	mount("cgroup", "/sys/fs/cgroup/systemd", "cgroup", 0, "none,name=systemd")
+	mount("cgroup", "/sys/fs/cgroup/systemd", "cgroup2", 0, "none,name=systemd")
 
 	// make / rshared
 	mount("", "/", "", rec|shared, "")

--- a/pkg/cli/rc/rc.go
+++ b/pkg/cli/rc/rc.go
@@ -231,17 +231,18 @@ func doMounts() {
 	// misc /proc mounted fs
 	mountSilent("binfmt_misc", "/proc/sys/fs/binfmt_misc", "binfmt_misc", noexec|nosuid|nodev, "")
 
+	// cgroup2 root is mounted in mtab
 	// mount cgroup root tmpfs
-	mount("cgroup_root", "/sys/fs/cgroup", "tmpfs", nodev|noexec|nosuid, "mode=755,size=10m")
+	// mount("none", "/sys/fs/cgroup", "cgroup2", nodev|noexec|nosuid, "mode=755,size=10m")
 	// mount cgroups filesystems for all enabled cgroups
-	for _, cg := range cgroupList() {
-		path := filepath.Join("/sys/fs/cgroup", cg)
-		mkdir(path, 0555)
-		mount(cg, path, "cgroup2", noexec|nosuid|nodev, cg)
-	}
+	// for _, cg := range cgroupList() {
+	// 	path := filepath.Join("/sys/fs/cgroup", cg)
+	// 	mkdir(path, 0555)
+	// 	mount(cg, path, "cgroup2", noexec|nosuid|nodev, cg)
+	// }
 
 	// use hierarchy for memory
-	write("/sys/fs/cgroup/memory/memory.use_hierarchy", "1")
+	//write("/sys/fs/cgroup/memory/memory.use_hierarchy", "1")
 
 	// many things assume systemd
 	mkdir("/sys/fs/cgroup/systemd", 0555)

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker image prune
+docker system prune

--- a/scripts/images
+++ b/scripts/images
@@ -55,9 +55,19 @@ copy_all()
         echo $(readlink -f ${OUTPUT})
         rm -rf output
         docker cp ${ID}:/output .
-        docker rm -fv $ID
+        docker_rm $ID
         cp ./output/* ${OUTPUT}/
         rm -rf ./output
         cd ..
     done
+}
+
+docker_rm()
+{
+    ID=$1
+    until docker rm -fv $ID
+    do
+        echo "..."
+        sleep 1
+    done    
 }

--- a/scripts/images
+++ b/scripts/images
@@ -55,7 +55,7 @@ copy_all()
         echo $(readlink -f ${OUTPUT})
         rm -rf output
         docker cp ${ID}:/output .
-        #docker rm -fv $ID
+        docker rm -fv $ID
         cp ./output/* ${OUTPUT}/
         rm -rf ./output
         cd ..

--- a/scripts/images
+++ b/scripts/images
@@ -55,7 +55,7 @@ copy_all()
         echo $(readlink -f ${OUTPUT})
         rm -rf output
         docker cp ${ID}:/output .
-        docker rm -fv $ID
+        #docker rm -fv $ID
         cp ./output/* ${OUTPUT}/
         rm -rf ./output
         cd ..

--- a/scripts/package
+++ b/scripts/package
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+#set -e
 
 echo "Packaging"
 
@@ -23,7 +23,15 @@ mkdir -p ./build
 ID=$(docker create ${REPO}/k3os-package:${TAG})
 docker cp ${ID}:/output/k3os ./build/
 echo "Removing $ID"
-#docker rm -fv $ID
+
+ec=1
+while [ 1 ]; do
+  docker rm -fv $ID
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  sleep 1
+done
 
 echo "Step 3"
 docker build \

--- a/scripts/package
+++ b/scripts/package
@@ -24,8 +24,11 @@ ID=$(docker create ${REPO}/k3os-package:${TAG})
 docker cp ${ID}:/output/k3os ./build/
 echo "Removing $ID"
 
-sleep 5;
-docker rm -fv $ID
+until docker rm -fv $ID
+do
+  echo "..."
+  sleep 1
+done
 
 echo "Step 3"
 docker build \

--- a/scripts/package
+++ b/scripts/package
@@ -23,12 +23,7 @@ mkdir -p ./build
 ID=$(docker create ${REPO}/k3os-package:${TAG})
 docker cp ${ID}:/output/k3os ./build/
 echo "Removing $ID"
-
-until docker rm -fv $ID
-do
-  echo "..."
-  sleep 1
-done
+docker_rm $ID
 
 echo "Step 3"
 docker build \

--- a/scripts/package
+++ b/scripts/package
@@ -24,14 +24,8 @@ ID=$(docker create ${REPO}/k3os-package:${TAG})
 docker cp ${ID}:/output/k3os ./build/
 echo "Removing $ID"
 
-ec=1
-while [ 1 ]; do
-  docker rm -fv $ID
-  if [ $? -eq 0 ]; then
-    break
-  fi
-  sleep 1
-done
+sleep 5;
+docker rm -fv $ID
 
 echo "Step 3"
 docker build \

--- a/scripts/package
+++ b/scripts/package
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo "Packaging"
+
 source $(dirname $0)/version
 source $(dirname $0)/images
 
@@ -8,17 +10,22 @@ cd $(dirname $0)/..
 
 DIST=$(pwd)/dist/artifacts
 
+echo "Step 1"
 pushd images/output
 build_all "$@"
 mkdir -p ${DIST}
+echo "Step 1.5"
 copy_all ${DIST} "$@"
 popd
 
+echo "Step 2"
 mkdir -p ./build
 ID=$(docker create ${REPO}/k3os-package:${TAG})
 docker cp ${ID}:/output/k3os ./build/
-docker rm -fv $ID
+echo "Removing $ID"
+#docker rm -fv $ID
 
+echo "Step 3"
 docker build \
   --build-arg ARCH=${ARCH} \
   --build-arg REPO=${REPO} \
@@ -28,6 +35,7 @@ docker build \
   --tag ${REPO}/k3os:${TAG} \
   --tag ${REPO}/k3os:latest \
 .
+echo "Step 4"
 docker image save --output ./dist/images.tar \
   ${REPO}/k3os:${TAG} \
   ${REPO}/k3os:latest

--- a/scripts/version
+++ b/scripts/version
@@ -7,6 +7,8 @@ fi
 COMMIT=$(git rev-parse --short HEAD)
 GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 
+echo "Git tag: ${DRONE_TAG}:${GIT_TAG}:${DIRTY}"
+
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
@@ -16,6 +18,9 @@ fi
 if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
 fi
+
+echo ${VERSION}
+exit 1
 
 ARCH=${ARCH:-"amd64"}
 TAG=${TAG:-"${VERSION}-${ARCH}"}

--- a/scripts/version
+++ b/scripts/version
@@ -7,8 +7,6 @@ fi
 COMMIT=$(git rev-parse --short HEAD)
 GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 
-echo "Git tag: ${DRONE_TAG}:${GIT_TAG}:${DIRTY}"
-
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
@@ -18,9 +16,6 @@ fi
 if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
 fi
-
-echo ${VERSION}
-exit 1
 
 ARCH=${ARCH:-"amd64"}
 TAG=${TAG:-"${VERSION}-${ARCH}"}


### PR DESCRIPTION
This PR:
- Upgrades k3s to `v1.32.0+k3s1`
- Drops the custom built kernel in favor of the `6.8.0-51-generic` Ubuntu kernel
- Upgrades the Alpine base image to `3.21` with cgroupsv2
- Adds tailscale support